### PR TITLE
In-site Links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,10 @@ disqus_shortname: # disqus comment thread for post header options. ( leave blank
 facebook_appid:   # appid for like button, remove from /_includes/share.html if unwanted.
 google_analytics: # set tracking, remove from /javascripts/basic.js if unwanted.
 
+insitelinks:
+  - name:         About
+    url:          /about
+    
 links: 
   - name:         Blog
     url:          http://muan.co

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -1,5 +1,8 @@
 <div class="block">
-  <a target="_top" class="main" href="/about">About</a>
+  <!--<a target="_top" class="main" href="/about">About</a>-->
+  {% for link in site.insitelinks %}
+    <a target="_top" class="main" href="{{ link.url }}">{{ link.name }}</a>
+    {% endfor %}
   {% for link in site.links %}
     <a target="_blank" class="main" href="{{ link.url }}">{{ link.name }}</a>
   {% endfor %}


### PR DESCRIPTION
Some people maybe want to add more pages. In the `_config.yml`, links add here wii display in a new page. It is not convenient to add a in site page, like About page. Now people may add links under `insitelinks`, and these links will be opened in the same page. 
