### PR TITLE
Remove border around image link

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -16,6 +16,9 @@ body {
   body, body * {
     -webkit-font-smoothing: antialiased; }
 
+img {
+  border: none; }
+
 #go-back-home {
   margin: 40px 0 0; }
   #go-back-home:hover {


### PR DESCRIPTION
If you view the page in Internet Explorer, there is a blue border around the scribble image. I added a CSS rule to remove it.
