### PR TITLE
fix code block on mobile

### DIFF
--- a/_assets/style.scss
+++ b/_assets/style.scss
@@ -178,9 +178,8 @@ section.post {
   text-align: left;
   border-top: 0; 
   padding: 0;
-  > *:not(.highlight) { padding: 0 60px; }
-  > ul, > ol { padding: 0 80px; }
-  ul, ol { ul, ol { margin-left: 20px; } }
+  > * { padding: 0 60px; }
+  ul, ol { ul, ol { margin-left: 20px; padding: 0; } }
   h1 {
     text-transform: uppercase;
     text-align: center;
@@ -226,13 +225,13 @@ section.post, section > p {
       white-space: normal;
     }
   }
-  li .highlight { margin: 10px 0; }
+  li .highlight { padding: 0 10px; }
   li p { margin-bottom: 5px; }
 }
 .highlight { margin: 0; padding: 0; }
 pre {
   overflow-x: auto;
-  padding: 10px 60px;
+  padding: 10px 0;
   width: 100%;
   line-height: 1.2em;
   @include box-sizing(border-box);

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -242,12 +242,11 @@ section.post {
   text-align: left;
   border-top: 0;
   padding: 0; }
-  section.post > *:not(.highlight) {
+  section.post > * {
     padding: 0 60px; }
-  section.post > ul, section.post > ol {
-    padding: 0 80px; }
   section.post ul ul, section.post ul ol, section.post ol ul, section.post ol ol {
-    margin-left: 20px; }
+    margin-left: 20px;
+    padding: 0; }
   section.post h1 {
     text-transform: uppercase;
     text-align: center;
@@ -307,7 +306,7 @@ section.post, section > p {
       width: 7px !important;
       white-space: normal; }
   section.post li .highlight, section > p li .highlight {
-    margin: 10px 0; }
+    padding: 0 10px; }
   section.post li p, section > p li p {
     margin-bottom: 5px; }
 
@@ -317,7 +316,7 @@ section.post, section > p {
 
 pre {
   overflow-x: auto;
-  padding: 10px 60px;
+  padding: 10px 0;
   width: 100%;
   line-height: 1.2em;
   -webkit-box-sizing: border-box;


### PR DESCRIPTION
Hey, I like how the `.highlight` code block looks like. It's like a silk gift wrap.

But there's too much padding on the left, when nested in a list or on a small screen. 

And the `<ul>` tag on chrome has `-webkit-padding-start` set to `40px`. The reset is added.

I updated the style.scss a little bit.

I've tested it on different screen size. It would affect the layout on bigger screens.

Thanks.
### Before.

![2014-01-28-230741_320x516_scrot](https://f.cloud.github.com/assets/469551/2026713/a17bcb72-889b-11e3-81d6-b5702c0b516b.png)
### After.

![2014-01-28-230736_320x516_scrot](https://f.cloud.github.com/assets/469551/2026733/264b95c6-889c-11e3-95a4-1daae4b5fd88.png)
