### PR TITLE
Changed pygments to highlighter in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ links:
   - name:         GitHub
     url:          http://github.com/muan
     external:     true
-pygments:         true
+highlighter:      pygments
 permalink:        pretty
 markdown:         redcarpet
 redcarpet:


### PR DESCRIPTION
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'.
Jekkyl v2.1.0
