### PR TITLE
Add default layout configuration for posts and pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,17 @@ markdown:         redcarpet
 redcarpet:
   extensions:
     - smart
+
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+      type: "posts"
+    values:
+      layout: "post"
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+      type: "pages"
+    values:
+      layout: "page"

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,8 @@ redcarpet:
   extensions:
     - smart
 
+exclude: [Rakefile README.md]
+
 defaults:
   -
     scope:


### PR DESCRIPTION
Hey, I made a few minor updates:
1. added default layout configuration for posts and pages, so that it's no longer required to do that for each post or page.
2. added a empty none layout file to prevent build warning
3. prevent Rakefile and README.md from being copied upon build

I hope that make sense.
