### PR TITLE
Fixed facebook_appid variable

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,6 +28,6 @@
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
   js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_GB/all.js#xfbml=1&appId=604714799556697";
+  js.src = "//connect.facebook.net/en_GB/all.js#xfbml=1&appId={{ site.facebook_appid }}";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>


### PR DESCRIPTION
The variable for the Facebook AppId wasn't used in the source. Instead, it was pointing to your own ID (604714799556697). Slightly surprised nobody found this before me.

Anyway, thanks for the awesome theme! :)