### PR TITLE
Adding permalink to 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,3 +1,7 @@
+---
+permalink: /404.html
+---
+
 <html>
   <head>
     <meta content='Scribble' property='og:title' />


### PR DESCRIPTION
Github [requires you to add](https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/) `permalink: 404.html` to the YAML front matter of the 404 page. This is to display a custom 404 page instead of letting Github handle it.
