### PR TITLE
Fixed incorrect links of signoff image, previous page button and next page button

### DIFF
--- a/_includes/pages.html
+++ b/_includes/pages.html
@@ -1,14 +1,14 @@
 <section class="paging">
   {% if page.previous %}
     <div class="left">
-      <a href="{{ page.previous.url }}">
+      <a href="{{ site.url }}{{ page.previous.url }}">
         ‹
       </a>
     </div>
   {% endif %}
   {% if page.next %}
     <div class="right">
-      <a href="{{page.next.url}}">
+      <a href="{{ site.url }}{{page.next.url}}">
         ›
       </a>
     </div>

--- a/_includes/signoff.html
+++ b/_includes/signoff.html
@@ -5,5 +5,5 @@
   <span class="muted">{{ page.date | date: "at %H:%M" }}</span>
 </p>
 <p>
-  <img src="/images/scribble3.png" alt="scribble" /> 
+  <img src="{{ site.url }}/images/scribble3.png" alt="scribble" />
 </p>


### PR DESCRIPTION
Add missing base url in the links of signoff image, previous page button and next page button. When the website is hosted as repository rather than ```yourusername.github.io```, these links are incorrect. In detail, the ```site.url``` is added in the path of following objects.

- Previous page and next page in pages.html

- Signoff image in signoff.html