### PR TITLE
Fix site title outside posts and text selection around pagination

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,8 +1,8 @@
-<section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+<section class="no-pointers fixed-l mw7 center w-100 top-50 tc pb4 nt4">
   {% if page.previous %}
-    <a href="{{ site.url }}{{ page.previous.url }}" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
+    <a href="{{ site.url }}{{ page.previous.url }}" class="pointers no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
   {% endif %}
   {% if page.next %}
-    <a href="{{ site.url }}{{page.next.url}}" class="no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
+    <a href="{{ site.url }}{{page.next.url}}" class="pointers no-underline f1 light-blue hover-silver nr5 fr-l ph3">›</a>
   {% endif %}
 </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,8 +2,15 @@
 <!doctype>
 <html lang="en">
   <head>
-    <meta content='{{ page.title }} - {{ site.title }}' name='title' />
-    <meta content='{{ page.title }} - {{ site.title }}' name='og:title' />
+    {% if page.title %}
+      <meta content='{{ page.title }} - {{ site.title }}' name='title' />
+      <meta content='{{ page.title }} - {{ site.title }}' name='og:title' />
+      <title>{{ page.title }} - {{ site.title }}</title>
+    {% else %}
+      <meta content='{{ site.title }}' name='title' />
+      <meta content='{{ site.title }}' name='og:title' />
+      <title>{{ site.title }}</title>
+    {% endif %}
     <title>{{ page.title }} - {{ site.title }}</title>
     {% include head.html %}
   </head>

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -2,6 +2,8 @@
 
 .bg-super-white { background: #f9f9f9; }
 .top-50 { top: 50% }
+.pointers { pointer-events: auto; }
+.no-pointers { pointer-events: none; }
 .link:hover { background: url(/images/line.png) repeat-x left bottom; }
 
 /* Markdown styles */


### PR DESCRIPTION
1) The main title would show " - Scribble", because page.title is empty, now it will show just "Scribble"
2) I made the pagination container ignore pointer events so that when selecting text, the pagination container doesn't confuse the cursor