### PR TITLE
Fix: pagination anchor makes links unclickable

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,4 +1,4 @@
-<section class="fixed-l mw7 center w-100 top-50 tc pb4 nt4">
+<section class="aspect-ratio fixed-l mw7 center w-100 top-50 tc nt4">
   {% if page.previous %}
     <a href="{{ site.url }}{{ page.previous.url }}" class="no-underline f1 light-blue hover-silver nl5 fl-l ph3">‹</a>
   {% endif %}


### PR DESCRIPTION
Sometimes the anchor `<section>` makes links on the middle of screen unclickable.
Set its height to zero, and cancel padding may solve.